### PR TITLE
Add XS definition of srand() from lib/XS/Tutorial/One.xs to lib/XS/Tu…

### DIFF
--- a/lib/XS/Tutorial/One.pm
+++ b/lib/XS/Tutorial/One.pm
@@ -79,6 +79,10 @@ C<XS::Tutorial::One>:
   unsigned int
   rand()
 
+  void
+  srand(seed)
+    unsigned int seed
+
 This file should be saved as F<lib/XS/Tutorial/One.xs>. The top half of the file
 is pure C code. The line beginning C<MODULE = XS::Tutorial::One> indicates the
 start of the XS code. This section will be parsed and compiled into C code by


### PR DESCRIPTION
The original code from One.pm fails one.t:

    t/one.t .. 1/? Undefined subroutine &XS::Tutorial::One::srand called at t/one.t line 9.

Add missing code from Tutorial/One.xs to POD in Tutorial/One.pm